### PR TITLE
replace 'value' attribute with 'content' for meta tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,20 +68,20 @@ console.log(metadata);
 /*
 
       <!-- og meta -->
-      <meta property="og:title" value="IT-Tools" />
-      <meta property="og:description" value="Lorem ipsum" />
-      <meta property="og:image:url" value="https://example.com/image.png" />
-      <meta property="og:image:alt" value="The image alt text" />
-      <meta property="og:image:width" value="600" />
-      <meta property="og:image:height" value="400" />
-      <meta property="og:locale" value="en_US" />
-      <meta property="og:site_name" value="IT-Tools" />
+      <meta property="og:title" content="IT-Tools" />
+      <meta property="og:description" content="Lorem ipsum" />
+      <meta property="og:image:url" content="https://example.com/image.png" />
+      <meta property="og:image:alt" content="The image alt text" />
+      <meta property="og:image:width" content="600" />
+      <meta property="og:image:height" content="400" />
+      <meta property="og:locale" content="en_US" />
+      <meta property="og:site_name" content="IT-Tools" />
 
       <!-- twitter meta -->
-      <meta name="twitter:title" value="IT-Tools" />
-      <meta name="twitter:description" value="Lorem ipsum" />
-      <meta name="twitter:image" value="https://example.com/image.png" />
-      <meta name="twitter:image:alt" value="The image alt text" />
+      <meta name="twitter:title" content="IT-Tools" />
+      <meta name="twitter:description" content="Lorem ipsum" />
+      <meta name="twitter:image" content="https://example.com/image.png" />
+      <meta name="twitter:image:alt" content="The image alt text" />
 
 
 */
@@ -109,12 +109,12 @@ console.log(metadata);
 /*
 
 <!-- og meta -->
-<meta property="og:music:author:name" value="Person 1" />
-<meta property="og:music:author:city" value="London" />
-<meta property="og:music:author:name" value="Person 2" />
-<meta property="og:music:author:city" value="Paris" />
-<meta property="og:music:tags" value="Tag 1" />
-<meta property="og:music:tags" value="Tag 2" />
+<meta property="og:music:author:name" content="Person 1" />
+<meta property="og:music:author:city" content="London" />
+<meta property="og:music:author:name" content="Person 2" />
+<meta property="og:music:author:city" content="Paris" />
+<meta property="og:music:tags" content="Tag 1" />
+<meta property="og:music:tags" content="Tag 2" />
 
 */
 ```
@@ -143,13 +143,13 @@ console.log(metadata);
 /*
 
 <!-- og meta -->
-<meta property="og:title" value="IT-Tools" />
-<meta property="og:description" value="Lorem ipsum" />
+<meta property="og:title" content="IT-Tools" />
+<meta property="og:description" content="Lorem ipsum" />
 
 <!-- twitter meta -->
-<meta name="twitter:title" value="Title for twitter" />
-<meta name="twitter:description" value="Lorem ipsum" />   // <-- present because of 'generateTwitterCompatibleMeta'
-<meta name="twitter:card" value="summary_large_image" />
+<meta name="twitter:title" content="Title for twitter" />
+<meta name="twitter:description" content="Lorem ipsum" />   // <-- present because of 'generateTwitterCompatibleMeta'
+<meta name="twitter:card" content="summary_large_image" />
 
 */
 ```

--- a/src/generator.test.ts
+++ b/src/generator.test.ts
@@ -9,8 +9,8 @@ describe('generators', () => {
         { key: 'og:description', value: 'Lorem ipsum' },
       ];
       expect(buildMetaStrings({ flatMetadata, type: 'property' })).to.eql([
-        '<meta property="og:title" value="it-tools" />',
-        '<meta property="og:description" value="Lorem ipsum" />',
+        '<meta property="og:title" content="it-tools" />',
+        '<meta property="og:description" content="Lorem ipsum" />',
       ]);
     });
   });
@@ -46,7 +46,7 @@ describe('generators', () => {
   describe('generateMeta', () => {
     it('generates meta strings', () => {
       expect(generateMeta({ title: 'it-tools', description: 'A website with tools' })).to.eql(
-        ['<!-- og meta -->', '<meta property="og:title" value="it-tools" />', '<meta property="og:description" value="A website with tools" />'].join('\n'),
+        ['<!-- og meta -->', '<meta property="og:title" content="it-tools" />', '<meta property="og:description" content="A website with tools" />'].join('\n'),
       );
     });
 
@@ -56,7 +56,7 @@ describe('generators', () => {
 
     it('handle array of values', () => {
       expect(generateMeta({ movie: { author: ['Jane Mi', 'John Do'] } })).to.eql(
-        '<!-- og meta -->\n<meta property="og:movie:author" value="Jane Mi" />\n<meta property="og:movie:author" value="John Do" />',
+        '<!-- og meta -->\n<meta property="og:movie:author" content="Jane Mi" />\n<meta property="og:movie:author" content="John Do" />',
       );
     });
 
@@ -64,12 +64,12 @@ describe('generators', () => {
       expect(generateMeta({ title: 'it-tools', description: 'Lorem ipsum', twitter: { title: 'it-tools twitter' } }, { generateTwitterCompatibleMeta: true })).to.eql(
         [
           '<!-- og meta -->',
-          '<meta property="og:title" value="it-tools" />',
-          '<meta property="og:description" value="Lorem ipsum" />',
+          '<meta property="og:title" content="it-tools" />',
+          '<meta property="og:description" content="Lorem ipsum" />',
           '',
           '<!-- twitter meta -->',
-          '<meta name="twitter:title" value="it-tools twitter" />',
-          '<meta name="twitter:description" value="Lorem ipsum" />',
+          '<meta name="twitter:title" content="it-tools twitter" />',
+          '<meta name="twitter:description" content="Lorem ipsum" />',
         ].join('\n'),
       );
     });
@@ -80,13 +80,13 @@ describe('generators', () => {
       ).to.eql(
         [
           '   <!-- og meta -->',
-          '   <meta property="og:title" value="it-tools" />',
-          '   <meta property="og:description" value="A website with tools" />',
-          '   <meta property="og:weird_case_url_stuff" value="true" />',
+          '   <meta property="og:title" content="it-tools" />',
+          '   <meta property="og:description" content="A website with tools" />',
+          '   <meta property="og:weird_case_url_stuff" content="true" />',
           '',
           '   <!-- twitter meta -->',
-          '   <meta name="twitter:title" value="it-tools" />',
-          '   <meta name="twitter:description" value="A website with tools" />',
+          '   <meta name="twitter:title" content="it-tools" />',
+          '   <meta name="twitter:description" content="A website with tools" />',
         ].join('\n'),
       );
     });

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -74,7 +74,7 @@ function flattenMetadata(metadata: unknown, { separator = ':', basePrefix = '' }
 }
 
 function metaToString({ flatMetadata: { key, value }, type }: { flatMetadata: MetadataFlat; type: string }) {
-  return `<meta ${type.trim()}="${key.trim()}" value="${value.trim()}" />`;
+  return `<meta ${type.trim()}="${key.trim()}" content="${value.trim()}" />`;
 }
 
 function buildMetaStrings({ flatMetadata, type }: { flatMetadata: MetadataFlat[]; type: string }) {


### PR DESCRIPTION
I used [Open Graph Meta Generator](https://it-tools.tech/og-meta-generator) to create og meta tags, but they weren’t working properly on the webpage. After investigating, I discovered the issue was that the meta tags were using the value attribute instead of the content attribute. So, I submitted a pull request to address this.